### PR TITLE
Add Flask-based print queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+uploads/
+queue.json
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# 3D Print Queue
+
+This is a minimal web application for managing a 3D print queue. Users can upload
+`.3mf` files, specify the plate number, reorder queued jobs and mark prints as
+started or finished. The app keeps track of which file is currently printing and
+which ones have already been printed.
+
+## Setup
+
+Install dependencies and run the server:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+By default uploaded files are stored in the `uploads/` folder and queue state is
+persisted in `queue.json`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,100 @@
+from flask import Flask, render_template, request, redirect, url_for
+import json
+import os
+import uuid
+
+DATA_FILE = 'queue.json'
+UPLOAD_FOLDER = 'uploads'
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+
+def load_queue():
+    if not os.path.exists(DATA_FILE):
+        return []
+    with open(DATA_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_queue(queue):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(queue, f, indent=2)
+
+
+@app.route('/')
+def index():
+    queue = load_queue()
+    return render_template('index.html', queue=queue)
+
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    plate = request.form.get('plate')
+    if not file or not file.filename.endswith('.3mf'):
+        return redirect(url_for('index'))
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    filename = f"{uuid.uuid4()}_{file.filename}"
+    file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+    item = {
+        'id': str(uuid.uuid4()),
+        'filename': filename,
+        'original_name': file.filename,
+        'plate': plate,
+        'status': 'queued'
+    }
+    queue = load_queue()
+    queue.append(item)
+    save_queue(queue)
+    return redirect(url_for('index'))
+
+
+@app.route('/move/<item_id>/<direction>')
+def move(item_id, direction):
+    queue = load_queue()
+    idx = next((i for i, x in enumerate(queue) if x['id'] == item_id), None)
+    if idx is not None:
+        if direction == 'up' and idx > 0:
+            queue[idx], queue[idx - 1] = queue[idx - 1], queue[idx]
+        elif direction == 'down' and idx < len(queue) - 1:
+            queue[idx], queue[idx + 1] = queue[idx + 1], queue[idx]
+    save_queue(queue)
+    return redirect(url_for('index'))
+
+
+@app.route('/start/<item_id>')
+def start(item_id):
+    queue = load_queue()
+    for item in queue:
+        if item['status'] == 'printing':
+            item['status'] = 'queued'
+    for item in queue:
+        if item['id'] == item_id:
+            item['status'] = 'printing'
+            break
+    save_queue(queue)
+    return redirect(url_for('index'))
+
+
+@app.route('/finish/<item_id>')
+def finish(item_id):
+    queue = load_queue()
+    for item in queue:
+        if item['id'] == item_id:
+            item['status'] = 'printed'
+            break
+    save_queue(queue)
+    return redirect(url_for('index'))
+
+
+@app.route('/delete/<item_id>')
+def delete(item_id):
+    queue = load_queue()
+    queue = [item for item in queue if item['id'] != item_id]
+    save_queue(queue)
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+flask
 bambulabs_api

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+  <title>3D Print Queue</title>
+  <style>
+    table, th, td { border: 1px solid black; border-collapse: collapse; }
+    th, td { padding: 5px; }
+  </style>
+</head>
+<body>
+  <h1>3D Print Queue</h1>
+  <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+    File: <input type="file" name="file" accept=".3mf" required>
+    Plate #: <input type="text" name="plate" required>
+    <input type="submit" value="Add to Queue">
+  </form>
+
+  <h2>Queue</h2>
+  <table>
+    <tr><th>File</th><th>Plate #</th><th>Status</th><th>Actions</th></tr>
+    {% for item in queue %}
+    <tr>
+      <td>{{ item.original_name }}</td>
+      <td>{{ item.plate }}</td>
+      <td>{{ item.status }}</td>
+      <td>
+        {% if item.status != 'printed' %}
+          <a href="{{ url_for('move', item_id=item.id, direction='up') }}">&uarr;</a>
+          <a href="{{ url_for('move', item_id=item.id, direction='down') }}">&darr;</a>
+          {% if item.status != 'printing' %}
+            <a href="{{ url_for('start', item_id=item.id) }}">Start</a>
+          {% endif %}
+          {% if item.status == 'printing' %}
+            <a href="{{ url_for('finish', item_id=item.id) }}">Finish</a>
+          {% endif %}
+          <a href="{{ url_for('delete', item_id=item.id) }}">Delete</a>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  <h2>Currently Printing</h2>
+  <ul>
+    {% for item in queue if item.status == 'printing' %}
+      <li>{{ item.original_name }} (Plate {{ item.plate }})</li>
+    {% endfor %}
+  </ul>
+
+  <h2>Printed</h2>
+  <ul>
+    {% for item in queue if item.status == 'printed' %}
+      <li>{{ item.original_name }} (Plate {{ item.plate }})</li>
+    {% endfor %}
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple Flask app for uploading `.3mf` files and managing queue
- add basic HTML interface for reordering jobs and marking them printed
- document setup instructions in README
- ignore temporary files and uploads

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1b829d1883338cb7a6e23f30f902